### PR TITLE
Implement Connection State Cycle

### DIFF
--- a/.github/workflows/arduino-compile.yml
+++ b/.github/workflows/arduino-compile.yml
@@ -45,7 +45,7 @@ jobs:
             platform-name: avr:mega
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Compile examples
         uses: arduino/compile-sketches@v1
@@ -65,7 +65,7 @@ jobs:
 
       - name: Save memory usage change report as artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: ${{ env.SKETCHES_REPORTS_NAME }}
@@ -78,7 +78,7 @@ jobs:
     steps:
       # This step is needed to get the size data produced by the build jobs
       - name: Download sketches reports artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.SKETCHES_REPORTS_NAME }}
           path: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}

--- a/.github/workflows/esp32-compile.yml
+++ b/.github/workflows/esp32-compile.yml
@@ -48,7 +48,7 @@ jobs:
                 source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install ESP32 platform dependencies
         if: matrix.board.platform-name == 'esp32:esp32'
@@ -77,7 +77,7 @@ jobs:
 
       - name: Save memory usage change report as artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: ${{ env.SKETCHES_REPORTS_NAME }}
@@ -90,7 +90,7 @@ jobs:
     steps:
       # This step is needed to get the size data produced by the build jobs
       - name: Download sketches reports artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.SKETCHES_REPORTS_NAME }}
           path: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}

--- a/.github/workflows/esp8266-compile.yml
+++ b/.github/workflows/esp8266-compile.yml
@@ -51,7 +51,7 @@ jobs:
                 version: 3.1.1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Compile examples
         uses: arduino/compile-sketches@v1
@@ -76,7 +76,7 @@ jobs:
 
       - name: Save memory usage change report as artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: ${{ env.SKETCHES_REPORTS_NAME }}
@@ -89,7 +89,7 @@ jobs:
     steps:
       # This step is needed to get the size data produced by the build jobs
       - name: Download sketches reports artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.SKETCHES_REPORTS_NAME }}
           path: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}

--- a/.github/workflows/espidf-compile-v4.4.yml
+++ b/.github/workflows/espidf-compile-v4.4.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Build send data example on v4.4

--- a/.github/workflows/espidf-compile-v5.1.yml
+++ b/.github/workflows/espidf-compile-v5.1.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Build send data example on v5.1

--- a/.github/workflows/espressif_upload.yml
+++ b/.github/workflows/espressif_upload.yml
@@ -9,7 +9,7 @@ jobs:
   upload_components:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
 

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     
     - name: Build doxygen documentation
       uses: mattnotmitt/doxygen-action@v1.9.5

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Vscode settings
+.vscode
+
 # Prerequisites
 *.d
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,4 +37,4 @@ if(ESP_PLATFORM)
 	return()
 endif()
 
-project(ThingsBoardClientSDK VERSION 0.15.0)
+project(ThingsBoardClientSDK VERSION 0.16.0)

--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ For that a `class` needs to inherit the `API_Implemenatation` class and `overrid
 
 class Custom_API_Implementation : public IAPI_Implementation {
   public:
+    ~Custom_API_Implementation() override = default;
+
     API_Process_Type Get_Process_Type() override {
         return API_Process_Type::JSON;
     }
@@ -452,6 +454,10 @@ For that a `class` needs to inherit the `IUpdater` interface and `override` the 
 
 class Custom_Updater : public IUpdater {
   public:
+    ~Custom_Updater() override {
+        reset();
+    }
+
     bool begin(size_t const & firmware_size) override {
         return true;
     }
@@ -497,6 +503,8 @@ For that a `class` needs to inherit the `IHTTP_Client` interface and `override` 
 
 class Custom_HTTP_Client : public IHTTP_Client {
   public:
+    ~Custom_HTTP_Client() override = default;
+
     void set_keep_alive(bool keep_alive) override {
         // Nothing to do
     }
@@ -565,6 +573,8 @@ For that a `class` needs to inherit the `IMQTT_Client` interface and `override` 
 
 class Custom_MQTT_Client : public IMQTT_Client {
   public:
+    ~Custom_MQTT_Client() override = default;
+
     void set_data_callback(Callback<void, char *, uint8_t *, unsigned int>::function callback) override {
         // Nothing to do
     }

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Alternatively to remove the need for the `MaxResponse`template argument in the c
 The possible event subscription classes that are passed to internal methods, use arrays which reside on the stack those require the `MaxSubscriptions` template argument to be passed in the constructor template list. The default value is 1, if the method call attempts to subscribe more than that many events in total, the `"Serial Monitor"` window will get a respective log showing an error:
 
 ```
-[TB] Too many shared attribute update subscriptions, increase MaxSubscriptions or unsubscribe
+[TB] Too many (shared attribute update) subscriptions, increase (MaxSubscriptions) or unsubscribe"
 ```
 
 Important is that both server-side RPC and request attribute values are temporary, meaning once the request has been received it is deleted, and it is therefore possible to subscribe another event again. However, all other subscriptions like client-side RPC or attribute update subscription are permanent meaning once the event has been subscribed we can only unsubscribe all events to make more room.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ All internal methods call attempt to utilize the stack as far as possible and co
 
 ### Too much data fields must be serialized
 
-The `sendAttributes` and `sendTelemetry` methods, use the [`StaticJsonDocument`](https://arduinojson.org/v6/api/staticjsondocument/) this requires the `MaxKeyValuePairAmount` template argument to be passed in the method template list. If more key-value pairs are sent than specified, the `"Serial Monitor"` window will get a respective log showing an error:
+The `Send_Attributes` and `Send_Telemetry` methods, use the [`StaticJsonDocument`](https://arduinojson.org/v6/api/staticjsondocument/) this requires the `MaxKeyValuePairAmount` template argument to be passed in the method template list. If more key-value pairs are sent than specified, the `"Serial Monitor"` window will get a respective log showing an error:
 
 ```
 [TB] Unable to serialize key-value json
@@ -611,6 +611,18 @@ class Custom_MQTT_Client : public IMQTT_Client {
 
     bool connected() override {
         return true;
+    }
+
+    MQTT_Connection_State get_connection_state() override {
+        return MQTT_Connection_State::DISCONNECTED;
+    }
+
+    MQTT_Connection_Error get_last_connection_error() override {
+        return MQTT_Connection_Error::NONE;
+    }
+
+    void set_connect_cycle_callback(Callback<void(MQTT_Connection_State, MQTT_Connection_Error)>::function callback) override {
+        // Nothing to do
     }
 
 #if THINGSBOARD_ENABLE_STREAM_UTILS

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ class Custom_API_Implementation : public IAPI_Implementation {
         // Nothing to do
     }
 
-    bool Compare_Response_Topic(char const * topic) const override {
+    bool Is_Response_Topic_Matching(char const * topic) const override {
         return true;
     }
 
@@ -387,7 +387,7 @@ class Custom_API_Implementation : public IAPI_Implementation {
         return true;
     }
 
-    bool Resubscribe_Topic() override {
+    bool Resubscribe_Permanent_Subscriptions() override {
         return true;
     }
 

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "ThingsBoard Client SDK"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.15.0
+PROJECT_NUMBER         = 0.16.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/examples/0000-arduino_send_telemetry/0000-arduino_send_telemetry.ino
+++ b/examples/0000-arduino_send_telemetry/0000-arduino_send_telemetry.ino
@@ -128,8 +128,8 @@ void loop() {
   // Uploads new telemetry to ThingsBoard using MQTT.
   // See https://thingsboard.io/docs/reference/mqtt-api/#telemetry-upload-api
   // for more details
-  tb.sendTelemetryData(TEMPERATURE_KEY, random(10, 31));
-  tb.sendTelemetryData(HUMIDITY_KEY, random(40, 90));
+  tb.Send_Telemetry_Data(TEMPERATURE_KEY, random(10, 31));
+  tb.Send_Telemetry_Data(HUMIDITY_KEY, random(40, 90));
 
   tb.loop();
 }

--- a/examples/0001-arduino_send_batch/0001-arduino_send_batch.ino
+++ b/examples/0001-arduino_send_batch/0001-arduino_send_batch.ino
@@ -144,7 +144,7 @@ void loop() {
   // for more details
   Telemetry* begin = data;
   Telemetry* end = data + TELEMETRY_SIZE;
-  tb.sendTelemetry<TELEMETRY_SIZE>(begin, end);
+  tb.Send_Telemetry<TELEMETRY_SIZE>(begin, end);
 
   Serial.println("Sending attributes data...");
 
@@ -168,7 +168,7 @@ void loop() {
   // for more details
   begin = attributes;
   end = attributes + ATTRIBUTES_SIZE;
-  tb.sendAttributes<ATTRIBUTES_SIZE>(begin, end);
+  tb.Send_Attributes<ATTRIBUTES_SIZE>(begin, end);
 
   tb.loop();
 }

--- a/examples/0003-esp8266_esp32_send_data/0003-esp8266_esp32_send_data.ino
+++ b/examples/0003-esp8266_esp32_send_data/0003-esp8266_esp32_send_data.ino
@@ -211,10 +211,10 @@ void loop() {
   // See https://thingsboard.io/docs/reference/http-api/#telemetry-upload-api
   // for more details
   Serial.println("Sending temperature data...");
-  tb.sendTelemetryData(TEMPERATURE_KEY, random(10, 31));
+  tb.Send_Telemetry_Data(TEMPERATURE_KEY, random(10, 31));
 
   Serial.println("Sending humidity data...");
-  tb.sendTelemetryData(HUMIDITY_KEY, random(40, 90));
+  tb.Send_Telemetry_Data(HUMIDITY_KEY, random(40, 90));
 
 #if !USING_HTTPS
   tb.loop();

--- a/examples/0003-esp8266_esp32_send_data/0003-esp8266_esp32_send_data.ino
+++ b/examples/0003-esp8266_esp32_send_data/0003-esp8266_esp32_send_data.ino
@@ -137,7 +137,11 @@ Arduino_MQTT_Client mqttClient(espClient);
 // Initialize used apis
 const std::array<IAPI_Implementation*, 0U> apis = {};
 // Initialize ThingsBoard instance with the maximum needed buffer size
-ThingsBoard tb(mqttClient, MAX_MESSAGE_RECEIVE_SIZE, MAX_MESSAGE_SEND_SIZE, Default_Max_Stack_Size, apis);
+#if THINGSBOARD_ENABLE_STREAM_UTILS
+ThingsBoard tb(mqttClient, MAX_MESSAGE_RECEIVE_SIZE, MAX_MESSAGE_SEND_SIZE, Default_Max_Stack_Size, Default_Buffering_Size, Default_Max_Response_Size, apis);
+#else
+ThingsBoard tb(mqttClient, MAX_MESSAGE_RECEIVE_SIZE, MAX_MESSAGE_SEND_SIZE, Default_Max_Stack_Size, Default_Max_Response_Size, apis);
+#endif
 #endif
 
 

--- a/examples/0003-esp8266_esp32_send_data/0003-esp8266_esp32_send_data.ino
+++ b/examples/0003-esp8266_esp32_send_data/0003-esp8266_esp32_send_data.ino
@@ -137,10 +137,18 @@ Arduino_MQTT_Client mqttClient(espClient);
 // Initialize used apis
 const std::array<IAPI_Implementation*, 0U> apis = {};
 // Initialize ThingsBoard instance with the maximum needed buffer size
+#if THINGSBOARD_ENABLE_DYNAMIC
 #if THINGSBOARD_ENABLE_STREAM_UTILS
 ThingsBoard tb(mqttClient, MAX_MESSAGE_RECEIVE_SIZE, MAX_MESSAGE_SEND_SIZE, Default_Max_Stack_Size, Default_Buffering_Size, Default_Max_Response_Size, apis.cbegin(), apis.cend());
 #else
 ThingsBoard tb(mqttClient, MAX_MESSAGE_RECEIVE_SIZE, MAX_MESSAGE_SEND_SIZE, Default_Max_Stack_Size, Default_Max_Response_Size, apis.cbegin(), apis.cend());
+#endif
+#else
+#if THINGSBOARD_ENABLE_STREAM_UTILS
+ThingsBoard tb(mqttClient, MAX_MESSAGE_RECEIVE_SIZE, MAX_MESSAGE_SEND_SIZE, Default_Max_Stack_Size, Default_Buffering_Size, apis.cbegin(), apis.cend());
+#else
+ThingsBoard tb(mqttClient, MAX_MESSAGE_RECEIVE_SIZE, MAX_MESSAGE_SEND_SIZE, Default_Max_Stack_Size, apis.cbegin(), apis.cend());
+#endif
 #endif
 #endif
 

--- a/examples/0003-esp8266_esp32_send_data/0003-esp8266_esp32_send_data.ino
+++ b/examples/0003-esp8266_esp32_send_data/0003-esp8266_esp32_send_data.ino
@@ -138,9 +138,9 @@ Arduino_MQTT_Client mqttClient(espClient);
 const std::array<IAPI_Implementation*, 0U> apis = {};
 // Initialize ThingsBoard instance with the maximum needed buffer size
 #if THINGSBOARD_ENABLE_STREAM_UTILS
-ThingsBoard tb(mqttClient, MAX_MESSAGE_RECEIVE_SIZE, MAX_MESSAGE_SEND_SIZE, Default_Max_Stack_Size, Default_Buffering_Size, Default_Max_Response_Size, apis);
+ThingsBoard tb(mqttClient, MAX_MESSAGE_RECEIVE_SIZE, MAX_MESSAGE_SEND_SIZE, Default_Max_Stack_Size, Default_Buffering_Size, Default_Max_Response_Size, apis.cbegin(), apis.cend());
 #else
-ThingsBoard tb(mqttClient, MAX_MESSAGE_RECEIVE_SIZE, MAX_MESSAGE_SEND_SIZE, Default_Max_Stack_Size, Default_Max_Response_Size, apis);
+ThingsBoard tb(mqttClient, MAX_MESSAGE_RECEIVE_SIZE, MAX_MESSAGE_SEND_SIZE, Default_Max_Stack_Size, Default_Max_Response_Size, apis.cbegin(), apis.cend());
 #endif
 #endif
 

--- a/examples/0004-arduino-sim900_send_telemetry/0004-arduino-sim900_send_telemetry.ino
+++ b/examples/0004-arduino-sim900_send_telemetry/0004-arduino-sim900_send_telemetry.ino
@@ -146,10 +146,10 @@ void loop() {
   // See https://thingsboard.io/docs/reference/http-api/#telemetry-upload-api
   // for more details
   Serial.println("Sending temperature data...");
-  tb.sendTelemetryData(TEMPERATURE_KEY, random(10, 31));
+  tb.Send_Telemetry_Data(TEMPERATURE_KEY, random(10, 31));
 
   Serial.println("Sending humidity data...");
-  tb.sendTelemetryData(HUMIDITY_KEY, random(40, 90));
+  tb.Send_Telemetry_Data(HUMIDITY_KEY, random(40, 90));
 
   tb.loop();
 }

--- a/examples/0005-arduino-sim900_send_telemetry_http/0005-arduino-sim900_send_telemetry_http.ino
+++ b/examples/0005-arduino-sim900_send_telemetry_http/0005-arduino-sim900_send_telemetry_http.ino
@@ -133,8 +133,8 @@ void loop() {
   // See https://thingsboard.io/docs/reference/http-api/#telemetry-upload-api
   // for more details
   Serial.println("Sending temperature data...");
-  tb.sendTelemetryData(TEMPERATURE_KEY, random(10, 31));
+  tb.Send_Telemetry_Data(TEMPERATURE_KEY, random(10, 31));
 
   Serial.println("Sending humidity data...");
-  tb.sendTelemetryData(HUMIDITY_KEY, random(40, 90));
+  tb.Send_Telemetry_Data(HUMIDITY_KEY, random(40, 90));
 }

--- a/examples/0006-esp8266_esp32_process_shared_attribute_update/0006-esp8266_esp32_process_shared_attribute_update.ino
+++ b/examples/0006-esp8266_esp32_process_shared_attribute_update/0006-esp8266_esp32_process_shared_attribute_update.ino
@@ -153,9 +153,15 @@ bool reconnect() {
 /// @param data Data containing the shared attributes that were changed and their current value
 void processSharedAttributeUpdate(const JsonObjectConst &data) {
   for (auto it = data.begin(); it != data.end(); ++it) {
-    Serial.println(it->key().c_str());
-    // Shared attributes have to be parsed by their type.
-    Serial.println(it->value().as<const char*>());
+    if (it->value().is<const char *>()) {
+      Serial.printf("Key: %s, Value: %s", it->key().c_str(), it->value().as<const char*>());
+    }
+    else if (it->value().is<int>()) {
+      Serial.printf("Key: %s, Value: %d", it->key().c_str(), it->value().as<int>());
+    }
+    else {
+      Serial.printf("Key: %s", it->key().c_str());
+    }
   }
 
   const size_t jsonSize = Helper::Measure_Json(data);

--- a/examples/0008-esp8266_esp32_provision_device/0008-esp8266_esp32_provision_device.ino
+++ b/examples/0008-esp8266_esp32_provision_device/0008-esp8266_esp32_provision_device.ino
@@ -273,8 +273,8 @@ void loop() {
       }
     } else {
       Serial.println("Sending telemetry...");
-      tb.sendTelemetryData(TEMPERATURE_KEY, 22);
-      tb.sendTelemetryData(HUMIDITY_KEY, 42.5);
+      tb.Send_Telemetry_Data(TEMPERATURE_KEY, 22);
+      tb.Send_Telemetry_Data(HUMIDITY_KEY, 42.5);
     }
   }
 

--- a/examples/0014-espressif_esp32_send_data/main/0014-espressif_esp32_send_data.cpp
+++ b/examples/0014-espressif_esp32_send_data/main/0014-espressif_esp32_send_data.cpp
@@ -156,8 +156,8 @@ extern "C" void app_main() {
             tb.connect(THINGSBOARD_SERVER, TOKEN, THINGSBOARD_PORT);
         }
 
-        tb.sendTelemetryData(TEMPERATURE_KEY, esp_random());
-        tb.sendTelemetryData(HUMIDITY_KEY, esp_random());
+        tb.Send_Telemetry_Data(TEMPERATURE_KEY, esp_random());
+        tb.Send_Telemetry_Data(HUMIDITY_KEY, esp_random());
 
         tb.loop();
 

--- a/examples/0017-espressif_esp32_process_shared_attribute_update/main/0017-espressif_esp32_process_shared_attribute_update.cpp
+++ b/examples/0017-espressif_esp32_process_shared_attribute_update/main/0017-espressif_esp32_process_shared_attribute_update.cpp
@@ -146,7 +146,15 @@ void InitWiFi() {
 /// @param data Data containing the shared attributes that were changed and their current value
 void processSharedAttributeUpdate(const JsonObjectConst &data) {
     for (auto it = data.begin(); it != data.end(); ++it) {
-        ESP_LOGI("MAIN", "Key: %s, Value: %s", it->key().c_str(), it->value().as<const char*>());
+        if (it->value().is<const char *>()) {
+            ESP_LOGI("MAIN", "Key: %s, Value: %s", it->key().c_str(), it->value().as<const char*>());
+        }
+        else if (it->value().is<int>()) {
+            ESP_LOGI("MAIN", "Key: %s, Value: %d", it->key().c_str(), it->value().as<int>());
+        }
+        else {
+            ESP_LOGI("MAIN", "Key: %s", it->key().c_str());
+        }
     }
 
     const size_t jsonSize = Helper::Measure_Json(data);

--- a/examples/0018-espressif_esp32_provision_device/main/0018-espressif_esp32_provision_device.cpp
+++ b/examples/0018-espressif_esp32_provision_device/main/0018-espressif_esp32_provision_device.cpp
@@ -237,6 +237,10 @@ void provision_device(void *pvParameters) {
         return;
     }
 
+    while (!tb.connected()) {
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
+    }
+
     // Prepare and send the provision request
     const Provision_Callback provisionCallback(Access_Token(), &processProvisionResponse, PROVISION_DEVICE_KEY, PROVISION_DEVICE_SECRET, device_name.c_str(), REQUEST_TIMEOUT_MICROSECONDS, &requestTimedOut);
     provisionRequestSent = prov.Provision_Request(provisionCallback);

--- a/examples/0019-esp8266_esp32_send_attributes/0019-esp8266_esp32_send_attributes.ino
+++ b/examples/0019-esp8266_esp32_send_attributes/0019-esp8266_esp32_send_attributes.ino
@@ -210,10 +210,10 @@ void loop() {
 
   // Send each attribute individually
   Serial.println("Sending device type attribute...");
-  tb.sendAttributeData(DEVICE_TYPE_KEY, SENSOR_VALUE);
+  tb.Send_Attribute_Data(DEVICE_TYPE_KEY, SENSOR_VALUE);
 
   Serial.println("Sending active attribute...");
-  tb.sendAttributeData(ACTIVE_KEY, false);
+  tb.Send_Attribute_Data(ACTIVE_KEY, false);
 
 
   // Send attributes in a batch
@@ -228,9 +228,9 @@ void loop() {
   Telemetry* begin = attributes;
   Telemetry* end = attributes + ATTRIBUTES_SIZE;
 #if THINGSBOARD_ENABLE_DYNAMIC
-  tb.sendAttributes(begin, end);
+  tb.Send_Attributes(begin, end);
 #else
-  tb.sendAttributes<ATTRIBUTES_SIZE>(begin, end);
+  tb.Send_Attributes<ATTRIBUTES_SIZE>(begin, end);
 #endif // THINGSBOARD_ENABLE_DYNAMIC
 
 #if !USING_HTTPS

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.15.0"
+version: "0.16.0"
 description: Provides access to ThingsBoard platform over the MQTT protocol or alternatively over HTTP/S.
 url: https://github.com/thingsboard/thingsboard-client-sdk
 dependencies:

--- a/keywords.txt
+++ b/keywords.txt
@@ -36,11 +36,11 @@ Send_Json   KEYWORD2
 Send_Json_String    KEYWORD2
 Claim_Request   KEYWORD2
 Provision_Request   KEYWORD2
-sendTelemetryData   KEYWORD2
-sendTelemetry   KEYWORD2
+Send_Telemetry_Data   KEYWORD2
+Send_Telemetry   KEYWORD2
 sendTelemetryJson   KEYWORD2
-sendAttributeData   KEYWORD2
-sendAttributes  KEYWORD2
+Send_Attribute_Data   KEYWORD2
+Send_Attributes  KEYWORD2
 sendAttributeJSON   KEYWORD2
 Client_Attributes_Request   KEYWORD2
 RPC_Subscribe   KEYWORD2

--- a/library.json
+++ b/library.json
@@ -27,7 +27,7 @@
         },
         "Update"
     ],
-    "version": "0.15.0",
+    "version": "0.16.0",
     "examples": "examples/*/*.ino",
     "frameworks": "*",
     "license": "MIT"

--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
 # See https://arduino.github.io/arduino-cli/0.35/library-specification/#libraryproperties-file-format for more information on the formatting
 name=ThingsBoard
-version=0.15.0
+version=0.16.0
 author=ThingsBoard Team
 maintainer=ThingsBoard Team
 sentence=ThingsBoard library for Arduino.

--- a/src/Arduino_ESP32_Updater.cpp
+++ b/src/Arduino_ESP32_Updater.cpp
@@ -6,6 +6,10 @@
 // Library include.
 #include <Update.h>
 
+Arduino_ESP32_Updater::~Arduino_ESP32_Updater() {
+    reset();
+}
+
 bool Arduino_ESP32_Updater::begin(size_t const & firmware_size) {
     return Update.begin(firmware_size);
 }

--- a/src/Arduino_ESP32_Updater.h
+++ b/src/Arduino_ESP32_Updater.h
@@ -14,6 +14,8 @@
 /// under the hood to write the given binary firmware data into flash memory so we can restart with newly received firmware
 class Arduino_ESP32_Updater : public IUpdater {
   public:
+    ~Arduino_ESP32_Updater() override;
+
     bool begin(size_t const & firmware_size) override;
   
     size_t write(uint8_t * payload, size_t const & total_bytes) override;

--- a/src/Arduino_ESP8266_Updater.cpp
+++ b/src/Arduino_ESP8266_Updater.cpp
@@ -6,6 +6,10 @@
 // Library include.
 #include <Updater.h>
 
+Arduino_ESP8266_Updater::~Arduino_ESP8266_Updater() {
+    reset();
+}
+
 bool Arduino_ESP8266_Updater::begin(size_t const & firmware_size) {
     return Update.begin(firmware_size);
 }

--- a/src/Arduino_ESP8266_Updater.h
+++ b/src/Arduino_ESP8266_Updater.h
@@ -14,6 +14,8 @@
 /// under the hood to write the given binary firmware data into flash memory so we can restart with newly received firmware
 class Arduino_ESP8266_Updater : public IUpdater {
   public:
+    ~Arduino_ESP8266_Updater() override;
+
     bool begin(size_t const & firmware_size) override;
   
     size_t write(uint8_t * payload, size_t const & total_bytes) override;

--- a/src/Arduino_HTTP_Client.h
+++ b/src/Arduino_HTTP_Client.h
@@ -24,6 +24,8 @@ class Arduino_HTTP_Client : public IHTTP_Client {
     /// because using an unencrpyted connection, will allow 3rd parties to listen to the communication and impersonate the server sending payloads which might influence the device in unexpected ways
     Arduino_HTTP_Client(Client& transport_client, char const * host, uint16_t port);
 
+    ~Arduino_HTTP_Client() override = default;
+
     void set_keep_alive(bool keep_alive) override;
 
     int connect(char const * host, uint16_t port) override;

--- a/src/Arduino_MQTT_Client.cpp
+++ b/src/Arduino_MQTT_Client.cpp
@@ -39,23 +39,23 @@ void Arduino_MQTT_Client::set_server(char const * domain, uint16_t port) {
 }
 
 bool Arduino_MQTT_Client::connect(char const * client_id, char const * user_name, char const * password) {
-    update_connection_state(MQTT_Connection_State::CONNECTING)
+    update_connection_state(MQTT_Connection_State::CONNECTING);
     MQTT_Connection_Error const connection_error = connect_mqtt_client(client_id, user_name, password);
     bool const result = connection_error == MQTT_Connection_Error::NONE
     if (result) {
         m_connected_callback.Call_Callback();
-        update_connection_state(MQTT_Connection_State::CONNECTED)
+        update_connection_state(MQTT_Connection_State::CONNECTED);
         return result;
     }
     m_last_connection_error = connection_error;
-    update_connection_state(MQTT_Connection_State::ERROR)
+    update_connection_state(MQTT_Connection_State::ERROR);
     return result;
 }
 
 void Arduino_MQTT_Client::disconnect() {
-    update_connection_state(MQTT_Connection_State::DISCONNECTING)
+    update_connection_state(MQTT_Connection_State::DISCONNECTING);
     m_mqtt_client.disconnect();
-    update_connection_state(MQTT_Connection_State::DISCONNECTED)
+    update_connection_state(MQTT_Connection_State::DISCONNECTED);
 }
 
 bool Arduino_MQTT_Client::loop() {

--- a/src/Arduino_MQTT_Client.cpp
+++ b/src/Arduino_MQTT_Client.cpp
@@ -41,7 +41,7 @@ void Arduino_MQTT_Client::set_server(char const * domain, uint16_t port) {
 bool Arduino_MQTT_Client::connect(char const * client_id, char const * user_name, char const * password) {
     update_connection_state(MQTT_Connection_State::CONNECTING);
     MQTT_Connection_Error const connection_error = connect_mqtt_client(client_id, user_name, password);
-    bool const result = connection_error == MQTT_Connection_Error::NONE
+    bool const result = connection_error == MQTT_Connection_Error::NONE;
     if (result) {
         m_connected_callback.Call_Callback();
         update_connection_state(MQTT_Connection_State::CONNECTED);

--- a/src/Arduino_MQTT_Client.cpp
+++ b/src/Arduino_MQTT_Client.cpp
@@ -39,23 +39,23 @@ void Arduino_MQTT_Client::set_server(char const * domain, uint16_t port) {
 }
 
 bool Arduino_MQTT_Client::connect(char const * client_id, char const * user_name, char const * password) {
-    m_connection_state_changed_callback.Call_Callback(MQTT_Connection_State::CONNECTING);
+    update_connection_state(MQTT_Connection_State::CONNECTING)
     MQTT_Connection_Error const connection_error = connect_mqtt_client(client_id, user_name, password);
     bool const result = connection_error == MQTT_Connection_Error::NONE
     if (result) {
         m_connected_callback.Call_Callback();
-        m_connection_state_changed_callback.Call_Callback(MQTT_Connection_State::CONNECTED);
+        update_connection_state(MQTT_Connection_State::CONNECTED)
         return result;
     }
     m_last_connection_error = connection_error;
-    m_connection_state_changed_callback.Call_Callback(MQTT_Connection_State::ERROR);
+    update_connection_state(MQTT_Connection_State::ERROR)
     return result;
 }
 
 void Arduino_MQTT_Client::disconnect() {
-    m_connection_state_changed_callback.Call_Callback(MQTT_Connection_State::DISCONNECTING);
+    update_connection_state(MQTT_Connection_State::DISCONNECTING)
     m_mqtt_client.disconnect();
-    m_connection_state_changed_callback.Call_Callback(MQTT_Connection_State::DISCONNECTED);
+    update_connection_state(MQTT_Connection_State::DISCONNECTED)
 }
 
 bool Arduino_MQTT_Client::loop() {
@@ -114,6 +114,11 @@ MQTT_Connection_Error connect_mqtt_client(char const * client_id, char const * u
     m_mqtt_client.connect(client_id, user_name, password);
     int const current_state = m_mqtt_client.state();
     return current_state < 0 ?  MQTT_Connection_Error::REFUSE_SERVER_UNAVAILABLE : static_cast<MQTT_Connection_Error>(current_state);
+}
+
+void update_connection_state(MQTT_Connection_State new_state) {
+  m_connection_state = new_state;
+  m_connection_state_changed_callback.Call_Callback(get_connection_state(), get_last_connection_error());
 }
 
 #endif // ARDUINO

--- a/src/Arduino_MQTT_Client.cpp
+++ b/src/Arduino_MQTT_Client.cpp
@@ -110,13 +110,13 @@ size_t Arduino_MQTT_Client::write(uint8_t const * buffer, size_t const & size) {
 
 #endif // THINGSBOARD_ENABLE_STREAM_UTILS
 
-MQTT_Connection_Error connect_mqtt_client(char const * client_id, char const * user_name, char const * password) {
+MQTT_Connection_Error Arduino_MQTT_Client::connect_mqtt_client(char const * client_id, char const * user_name, char const * password) {
     m_mqtt_client.connect(client_id, user_name, password);
     int const current_state = m_mqtt_client.state();
     return current_state < 0 ?  MQTT_Connection_Error::REFUSE_SERVER_UNAVAILABLE : static_cast<MQTT_Connection_Error>(current_state);
 }
 
-void update_connection_state(MQTT_Connection_State new_state) {
+void Arduino_MQTT_Client::update_connection_state(MQTT_Connection_State new_state) {
   m_connection_state = new_state;
   m_connection_state_changed_callback.Call_Callback(get_connection_state(), get_last_connection_error());
 }

--- a/src/Arduino_MQTT_Client.h
+++ b/src/Arduino_MQTT_Client.h
@@ -22,6 +22,8 @@ class Arduino_MQTT_Client : public IMQTT_Client {
     /// but the actual type of connection does not matter (Ethernet or WiFi)
     Arduino_MQTT_Client(Client & transport_client);
 
+    ~Arduino_MQTT_Client() override = default;
+
     /// @brief Sets the client has to be used if the empty constructor was used initally
     /// @param transport_client Client that is used to send the actual payload via. MQTT, needs to implement the client interface,
     /// but the actual type of connection does not matter (Ethernet or WiFi)

--- a/src/Arduino_MQTT_Client.h
+++ b/src/Arduino_MQTT_Client.h
@@ -53,6 +53,12 @@ class Arduino_MQTT_Client : public IMQTT_Client {
 
     bool connected() override;
 
+    MQTT_Connection_State get_connection_state() override;
+
+    MQTT_Connection_Error get_last_connection_error() override;
+
+    void set_connection_state_changed_callback(Callback<void, MQTT_Connection_State, MQTT_Connection_Error>::function callback) override;
+
 #if THINGSBOARD_ENABLE_STREAM_UTILS
 
     bool begin_publish(char const * topic, size_t const & length) override;
@@ -70,8 +76,13 @@ class Arduino_MQTT_Client : public IMQTT_Client {
 #endif // THINGSBOARD_ENABLE_STREAM_UTILS
 
   private:
-    Callback<void> m_connected_callback = {}; // Callback that will be called as soon as the mqtt client has connected
-    PubSubClient   m_mqtt_client = {};        // Underlying MQTT client instance used to send data
+    MQTT_Connection_Error connect_mqtt_client(char const * client_id, char const * user_name, char const * password);
+
+    MQTT_Connection_State                                        m_connection_state = {};                  // Current connection state to the MQTT broker
+    MQTT_Connection_Error                                        m_last_connection_error = {};             // Last error that occured while trying to establish a connection to the MQTT broker
+    Callback<void, MQTT_Connection_State, MQTT_Connection_Error> m_connection_state_changed_callback = {}; // Callback that will be called as soon as the mqtt client connection changes
+    Callback<void>                                               m_connected_callback = {};                // Callback that will be called as soon as the mqtt client has connected
+    PubSubClient                                                 m_mqtt_client = {};                       // Underlying MQTT client instance used to send data
 };
 
 #endif // ARDUINO

--- a/src/Arduino_MQTT_Client.h
+++ b/src/Arduino_MQTT_Client.h
@@ -78,6 +78,10 @@ class Arduino_MQTT_Client : public IMQTT_Client {
   private:
     MQTT_Connection_Error connect_mqtt_client(char const * client_id, char const * user_name, char const * password);
 
+    /// @brief Updates the interal connection state and informs the subscribed subject, about changes to the internal state
+    /// @param new_state New state the connection to the MQTT broker is in now and the subject should be informed about
+    void update_connection_state(MQTT_Connection_State new_state);
+
     MQTT_Connection_State                                        m_connection_state = {};                  // Current connection state to the MQTT broker
     MQTT_Connection_Error                                        m_last_connection_error = {};             // Last error that occured while trying to establish a connection to the MQTT broker
     Callback<void, MQTT_Connection_State, MQTT_Connection_Error> m_connection_state_changed_callback = {}; // Callback that will be called as soon as the mqtt client connection changes

--- a/src/Array.h
+++ b/src/Array.h
@@ -8,16 +8,22 @@
 #include <assert.h>
 
 
-/// @brief Replacement data container for boards that do not support the C++ STL and therefore do not have the std::array class.
-/// @tparam T Type of the underlying data the list should point too.
-/// @tparam Capacity Amount of elements that can be saved into the underlying data structure allows to wrap a simple c-array and allocate it on the stack.
+/// @brief Replacement data container for boards that do not support the C++ STL and therefore do not have the std::array class
+/// @tparam T Type of the underlying data the list should point too
+/// @tparam Capacity Amount of elements that can be saved into the underlying data structure allows to wrap a simple c-array and allocate it on the stack
 template <typename T, size_t Capacity>
 class Array {
   public:
     using value_type = T;
 
-    /// @brief Constructor
-    Array(void) = default;
+    /// @brief Default constructor, simply initalizes the underlying c-style array with the necessary capacity.
+    /// That capacity always has to be bigger than 0, because initalizing a 0 length c-style array makes no sense
+    Array()
+      : m_elements()
+      , m_size(0U)
+    {
+        static_assert(Capacity > 0);
+    }
 
     /// @brief Constructor that allows compatibility with std::vector, simply forwards call to internal insert method and copies all data between the first and last iterator
     /// @tparam InputIterator Class that points to the begin and end iterator
@@ -27,8 +33,7 @@ class Array {
     /// @param last Iterator pointing to one past the end of the elements we want to copy into our underlying data container
     template<typename InputIterator>
     Array(InputIterator const & first, InputIterator const & last)
-      : m_elements()
-      , m_size(0U)
+      : Array()
     {
         insert(nullptr, first, last);
     }
@@ -41,8 +46,7 @@ class Array {
     /// @param container Data container with begin() and end() method that we want to copy fully into our underlying data container
     template<typename Container>
     Array(Container const & container)
-      : m_elements()
-      , m_size(0U)
+      : Array()
     {
         insert(nullptr, container.begin(), container.end());
     }

--- a/src/Attribute_Request.h
+++ b/src/Attribute_Request.h
@@ -43,6 +43,8 @@ class Attribute_Request : public IAPI_Implementation {
     /// @brief Constructor
     Attribute_Request() = default;
 
+    ~Attribute_Request() override = default;
+
     /// @brief Requests one client-side attribute calllback,
     /// that will be called if the key-value pair from the server for the given client-side attributes is received.
     /// Because the client-side attribute request is a single event subscription, meaning we only ever receive a response to our request once,

--- a/src/Attribute_Request.h
+++ b/src/Attribute_Request.h
@@ -276,7 +276,7 @@ class Attribute_Request : public IAPI_Implementation {
 #endif // THINGSBOARD_ENABLE_DYNAMIC
 #if !THINGSBOARD_ENABLE_DYNAMIC
         if (m_attribute_request_callbacks.size() + 1 > m_attribute_request_callbacks.capacity()) {
-            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, MAX_SUBSCRIPTIONS_TEMPLATE_NAME, CLIENT_SHARED_ATTRIBUTE_SUBSCRIPTIONS);
+            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, CLIENT_SHARED_ATTRIBUTE_SUBSCRIPTIONS, MAX_SUBSCRIPTIONS_TEMPLATE_NAME);
             return false;
         }
 #endif // !THINGSBOARD_ENABLE_DYNAMIC

--- a/src/Attribute_Request.h
+++ b/src/Attribute_Request.h
@@ -134,7 +134,7 @@ class Attribute_Request : public IAPI_Implementation {
         }
     }
 
-    bool Compare_Response_Topic(char const * topic) const override {
+    bool Is_Response_Topic_Matching(char const * topic) const override {
         return strncmp(ATTRIBUTE_RESPONSE_TOPIC, topic, strlen(ATTRIBUTE_RESPONSE_TOPIC)) == 0;
     }
 
@@ -142,7 +142,7 @@ class Attribute_Request : public IAPI_Implementation {
         return Attributes_Request_Unsubscribe();
     }
 
-    bool Resubscribe_Topic() override {
+    bool Resubscribe_Permanent_Subscriptions() override {
         m_attribute_request_callbacks.clear();
         return true;
     }
@@ -293,7 +293,7 @@ class Attribute_Request : public IAPI_Implementation {
     /// @return Whether unsubcribing the previously subscribed callbacks
     /// and from the  attribute response topic, was successful or not
     bool Attributes_Request_Unsubscribe() {
-        (void)Resubscribe_Topic();
+        (void)Resubscribe_Permanent_Subscriptions();
         return m_unsubscribe_topic_callback.Call_Callback(ATTRIBUTE_RESPONSE_SUBSCRIBE_TOPIC);
     }
 

--- a/src/Attribute_Request_Callback.h
+++ b/src/Attribute_Request_Callback.h
@@ -55,6 +55,8 @@ class Attribute_Request_Callback : public Callback<void, JsonObjectConst const &
         // Nothing to do
     }
 
+    ~Attribute_Request_Callback() override = default;
+
     /// @brief Gets the unique request identifier that is connected to the original request,
     /// and will be later used to verifiy which Attribute_Request_Callback
     /// is connected to which received client-side or shared attributes

--- a/src/Callback.h
+++ b/src/Callback.h
@@ -51,6 +51,11 @@ class Callback {
         // Nothing to do
     }
 
+    /// @brief Virtual default destructor, created to ensure that if a pointer to this class is used and deleted, we will also call the derived base class destructor.
+    /// Deleting a base class destructor that does not have a virtual destructor is undefined behaviour, because the derived class destructor originally instantiated with new is never called.
+    /// This can cause potential memory leaks, because derived classes can not clean up their internal members as expected and instead simply leak them
+    virtual ~Callback() = default;
+
     /// @brief Calls the callback that was subscribed, when this class instance was initally created.
     /// If the default constructor was used or a nullptr was passed instead of a valid function pointer,
     /// this method will check beforehand and simply return with a defaulted instance of the requested return variable

--- a/src/Callback_Watchdog.h
+++ b/src/Callback_Watchdog.h
@@ -47,8 +47,7 @@ class Callback_Watchdog : public Callback<void> {
     }
 
 #if THINGSBOARD_USE_ESP_TIMER
-    /// @brief Destructor
-    ~Callback_Watchdog() {
+    ~Callback_Watchdog() override {
         // Timer only has to deleted at the end of the lifetime of this object, to ensure no memory leak occurs.
         // But besides that the same timer can simply be stopped and restarted without needing to delete and create the timer again everytime.
         (void)esp_timer_delete(m_oneshot_timer);

--- a/src/Client_Side_RPC.h
+++ b/src/Client_Side_RPC.h
@@ -146,7 +146,7 @@ class Client_Side_RPC : public IAPI_Implementation {
         }
     }
 
-    bool Compare_Response_Topic(char const * topic) const override {
+    bool Is_Response_Topic_Matching(char const * topic) const override {
         return strncmp(RPC_RESPONSE_TOPIC, topic, strlen(RPC_RESPONSE_TOPIC)) == 0;
     }
 
@@ -154,7 +154,7 @@ class Client_Side_RPC : public IAPI_Implementation {
         return RPC_Request_Unsubscribe();
     }
 
-    bool Resubscribe_Topic() override {
+    bool Resubscribe_Permanent_Subscriptions() override {
         m_rpc_request_callbacks.clear();
         return Unsubscribe();
     }
@@ -205,7 +205,7 @@ class Client_Side_RPC : public IAPI_Implementation {
     /// @return Whether unsubcribing the previously subscribed callbacks
     /// and from the client-side RPC response topic, was successful or not
     bool RPC_Request_Unsubscribe() {
-        (void)Resubscribe_Topic();
+        (void)Resubscribe_Permanent_Subscriptions();
         return m_unsubscribe_topic_callback.Call_Callback(RPC_RESPONSE_SUBSCRIBE_TOPIC);
     }
 

--- a/src/Client_Side_RPC.h
+++ b/src/Client_Side_RPC.h
@@ -188,7 +188,7 @@ class Client_Side_RPC : public IAPI_Implementation {
     bool RPC_Request_Subscribe(RPC_Request_Callback const & callback, RPC_Request_Callback * & registered_callback) {
 #if !THINGSBOARD_ENABLE_DYNAMIC
         if (m_rpc_request_callbacks.size() + 1 > m_rpc_request_callbacks.capacity()) {
-            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, MAX_SUBSCRIPTIONS_TEMPLATE_NAME, CLIENT_SIDE_RPC_SUBSCRIPTIONS);
+            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, CLIENT_SIDE_RPC_SUBSCRIPTIONS, MAX_SUBSCRIPTIONS_TEMPLATE_NAME);
             return false;
         }
 #endif // !THINGSBOARD_ENABLE_DYNAMIC

--- a/src/Client_Side_RPC.h
+++ b/src/Client_Side_RPC.h
@@ -38,6 +38,8 @@ class Client_Side_RPC : public IAPI_Implementation {
     /// @brief Constructor
     Client_Side_RPC() = default;
 
+    ~Client_Side_RPC() override = default;
+
     /// @brief Requests one client-side RPC callback,
     /// that will be called if a response from the server for the method with the given name is received.
     /// Because the client-side RPC request is a single event subscription, meaning we only ever receive a response to our request once,

--- a/src/Client_Side_RPC.h
+++ b/src/Client_Side_RPC.h
@@ -155,6 +155,7 @@ class Client_Side_RPC : public IAPI_Implementation {
     }
 
     bool Resubscribe_Topic() override {
+        m_rpc_request_callbacks.clear();
         return Unsubscribe();
     }
 
@@ -204,7 +205,7 @@ class Client_Side_RPC : public IAPI_Implementation {
     /// @return Whether unsubcribing the previously subscribed callbacks
     /// and from the client-side RPC response topic, was successful or not
     bool RPC_Request_Unsubscribe() {
-        m_rpc_request_callbacks.clear();
+        (void)Resubscribe_Topic();
         return m_unsubscribe_topic_callback.Call_Callback(RPC_RESPONSE_SUBSCRIBE_TOPIC);
     }
 

--- a/src/Espressif_MQTT_Client.h
+++ b/src/Espressif_MQTT_Client.h
@@ -37,8 +37,7 @@ class Espressif_MQTT_Client : public IMQTT_Client {
     /// @brief Constructs a IMQTT_Client implementation which creates and empty esp_mqtt_client_config_t, which then has to be configured with the other methods in the class
     Espressif_MQTT_Client() = default;
 
-    /// @brief Destructor
-    ~Espressif_MQTT_Client() {
+    ~Espressif_MQTT_Client() override {
         (void)esp_mqtt_client_destroy(m_mqtt_client);
     }
 

--- a/src/Espressif_Updater.h
+++ b/src/Espressif_Updater.h
@@ -25,6 +25,10 @@ class Espressif_Updater : public IUpdater {
   public:
     Espressif_Updater() = default;
 
+    ~Espressif_Updater() override {
+        reset();
+    }
+
     bool begin(size_t const & firmware_size) override {
         esp_partition_t const * running = esp_ota_get_running_partition();
         esp_partition_t const * configured = esp_ota_get_boot_partition();

--- a/src/Helper.h
+++ b/src/Helper.h
@@ -55,7 +55,7 @@ class Helper {
     static size_t parseRequestId(char const * base_topic, char const * received_topic);
 
     /// @brief Calculates the total size of the string the serializeJson method would produce including the null end terminator.
-    /// Be aware that null terminator will later not be serialied in the serializeJson() call,
+    /// Be aware that null terminator will later not be serialized in the serializeJson() call,
     /// meaning the returned written amount of bytes is the return value of this method - 1.
     /// See https://arduinojson.org/v6/api/json/measurejson/ for more information on the underlying method used
     /// @tparam TSource Source class that should be used to serialize the json that is sent to the server

--- a/src/IAPI_Implementation.h
+++ b/src/IAPI_Implementation.h
@@ -57,11 +57,12 @@ class IAPI_Implementation {
 
     /// @brief Compares received response topic and the topic this api implementation handles responses on,
     /// messages from all other topics are ignored and only messages from topics that match are handled.
-    /// For the comparsion we either compare the full expected string with the null termination, if the response topic does not include additional parameters.
-    /// Example being shared attribute update (v1/devices/me/attributes) or we compare only before the null termination for topics that include additional parameters in the response.
+    /// For the comparsion we either compare the full expected string with the null termination,
+    /// if the response topic does not include additional parameters, example being shared attribute update (v1/devices/me/attributes).
+    /// Or we compare only before the null termination for topics that include additional parameters in the response.
     /// Like for example the original request id in the response of the attribute request (v1/devices/me/attributes/response/1)
     /// @return Whether the received response topic matches the topic this api implementation handles responses on
-    virtual bool Compare_Response_Topic(char const * topic) const = 0;
+    virtual bool Is_Response_Topic_Matching(char const * topic) const = 0;
 
     /// @brief Unsubcribes all callbacks, to clear up any ongoing subscriptions and stop receiving information over the previously subscribed topic
     /// @return Whether unsubcribing all the previously subscribed callbacks
@@ -71,7 +72,7 @@ class IAPI_Implementation {
     /// @brief Forwards the call to let the API clear up any ongoing single-event subscriptions (Provision, Attribute Request, RPC Request)
     /// and simply resubscribes the topic for all permanent subscriptions (RPC, Shared Attribute Update)
     /// @return Whether resubscribing was successfull or not
-    virtual bool Resubscribe_Topic() = 0;
+    virtual bool Resubscribe_Permanent_Subscriptions() = 0;
 
 #if !THINGSBOARD_USE_ESP_TIMER
     /// @brief Internal loop method to update inernal timers for API calls that can timeout.

--- a/src/IAPI_Implementation.h
+++ b/src/IAPI_Implementation.h
@@ -36,6 +36,9 @@ char constexpr TELEMETRY_TOPIC[] = "v1/devices/me/telemetry";
 /// @brief Base functionality required by all API implementation
 class IAPI_Implementation {
   public:
+    /// @copybrief Callback::~Callback
+    virtual ~IAPI_Implementation() {}
+
     /// @brief Returns the way the server response should be processed.
     /// Only ever uses one at the time, because the response is either unserialized data which we need to process as such (OTA Firmware Update)
     /// or actually JSON which needs to be serialized (everything else)

--- a/src/IHTTP_Client.h
+++ b/src/IHTTP_Client.h
@@ -21,6 +21,9 @@
 /// and for Espressif IDF the implementations has not been created yet, the implementations have been tested and should be compatible when used in conjunction with the ThingsBoardHttp client.
 class IHTTP_Client {
   public:
+    /// @copybrief Callback::~Callback
+    virtual ~IHTTP_Client() {}
+
     /// @brief Sets whether to close the HTTP connection for every single request and reconnect once a new request is sent
     /// @param keep_alive Enable or disable to keep the connection alive after a message has been sent.
     /// Is recommended to be always enabled to improve performance and speed, because opening a new connection takes a while especially when using HTTPS

--- a/src/IMQTT_Client.h
+++ b/src/IMQTT_Client.h
@@ -85,12 +85,18 @@ class IMQTT_Client {
     /// @return Whether the client could establish the connection successfully or not
     virtual bool connect(char const * client_id, char const * user_name, char const * password) = 0;
 
-    /// @brief Disconnects from a previously connected server and should release all used resources
+    /// @brief Force disconnects from the previously connected server and should release all used resources.
+    /// @note Be aware that @ref Espressif_MQTT_Client automatically reconnects, as long as @ref Espressif_MQTT_Client::set_disable_auto_reconnect was not set to true
     virtual void disconnect() = 0;
 
-    /// @brief Receives and sends any outstanding messages from and to the MQTT broker
-    /// @return Whether sending or receiving the oustanding the messages was successful or not,
-    /// should return false if an internal error occured or the connection has been lost
+    /// @brief Receives / sends any outstanding messages from and to the MQTT broker,
+    /// only required if the MQTT client is blocking and does not use a seperate task to process messages.
+    /// This is the case for @ref Arduino_MQTT_Client, which requires calls to this method to actually process the received and sent data.
+    /// For the @ref Espressif_MQTT_Client however, this method simply does nothing and never needs to be called,
+    /// because received and set data is processed using a seperate FreeRTOS task
+    /// @return Whether sending or receiving the oustanding the messages was successful or not.
+    /// Returns false if an internal error occured or the connection has been lost.
+    /// Exact state can be read from @ref get_connection_state and @ref get_last_connection_error
     virtual bool loop() = 0;
 
     /// @brief Sends the given payload over the previously established connection with connect

--- a/src/IMQTT_Client.h
+++ b/src/IMQTT_Client.h
@@ -32,6 +32,9 @@ class IMQTT_Client : public Print {
 class IMQTT_Client {
 #endif // THINGSBOARD_ENABLE_STREAM_UTILS
   public:
+    /// @copybrief Callback::~Callback
+    virtual ~IMQTT_Client() {}
+
     /// @brief Sets the callback that is called, if any message is received by the MQTT broker, including the topic string that the message was received over,
     /// as well as the payload data and the size of that payload data. Directly set by the used ThingsBoard client to its internal methods,
     /// therefore calling again and overriding as a user ist not recommended, unless you know what you are doing

--- a/src/IUpdater.h
+++ b/src/IUpdater.h
@@ -13,6 +13,9 @@
 /// @brief Updater interface that contains the method that a class that can be used to flash given binary data onto a device has to implement
 class IUpdater {
   public:
+    /// @copybrief Callback::~Callback
+    virtual ~IUpdater() {}
+
     /// @brief Initalizes the writing of the given data
     /// @param firmware_size Total size of the data that should be written, is done in multiple packets
     /// @return Whether initalizing the update was successful or not

--- a/src/MQTT_Connection_Error.h
+++ b/src/MQTT_Connection_Error.h
@@ -1,0 +1,18 @@
+#ifndef MQTT_Connection_Error_h
+#define MQTT_Connection_Error_h
+
+// Library include.
+#include <stdint.h>
+
+
+/// @brief Possible error states the MQTT broker connection can be in, if connecting the device to the MQTT broker failed or the device lost connection to the MQTT broker.
+enum class MQTT_Connection_Error : uint8_t {
+    NONE, ///< Connection accepted
+    REFUSE_PROTOCOL, ///< Connection failed because of wrong protocol
+    REFUSE_ID_REJECTED, ///< Connection failed because of rejected ID
+    REFUSE_SERVER_UNAVAILABLE, ///< Connection failed because of unavailable server
+    REFUSE_BAD_USERNAME, ///< Connection failed because of wrong user
+    REFUSE_NOT_AUTHORIZED ///< Connection failed because of wrong username or password
+};
+
+#endif // MQTT_Connection_Error_h

--- a/src/MQTT_Connection_State.h
+++ b/src/MQTT_Connection_State.h
@@ -1,0 +1,18 @@
+#ifndef MQTT_Connection_State_h
+#define MQTT_Connection_State_h
+
+// Library include.
+#include <stdint.h>
+
+
+/// @brief Possible states the MQTT broker connection can be in. Intermediate states connecting and disconnecting, are for the @ref Espressif_MQTT_Client which is non blocking.
+/// Meaning calling disconnect will not immediately disconnect from the cloud but instead require a while. In comparsion @ref Arduino_MQTT_Client is blocking, meaning we block until we disconnected or connected
+enum class MQTT_Connection_State : uint8_t {
+    DISCONNECTED, ///< Not yet connected or force disconnected from the MQTT broker. Loosing connection unexpectedly results in the ERROR state instead
+    CONNECTING, ///< Received request to connect to the MQTT broker and connection is currently ongoing. Once successfull will be in CONNECTED state or alternatively in ERROR state if the connection failed
+    CONNECTED, ///< Device has successfully connected to the MQTT broker. Should stay in this state until force disconnect is received or until error occurs in the connection to the MQTT broker
+    DISCONNECTING, ///< Received request to force disconnect from the MQTT broker. Should always result in DISCONNECTED state once processed
+    ERROR ///< State for failure to connect to the MQTT broker or loosing connection unexpectedly, can be deciphered in more detail using @ref MQTT_Connection_Error
+};
+
+#endif // MQTT_Connection_State_h

--- a/src/OTA_Firmware_Update.h
+++ b/src/OTA_Firmware_Update.h
@@ -42,6 +42,9 @@ char constexpr PAGE_BREAK[] = "=================================";
 char constexpr NEW_FW[] = "A new Firmware is available:";
 char constexpr FROM_TOO[] = "(%s) => (%s)";
 char constexpr DOWNLOADING_FW[] = "Attempting to download over MQTT...";
+char constexpr MQTT_TEMP_BUFFER_INCREASE[] = "Temporarily increasing receive buffer size for OTA update from (%u) too (%u)";
+char constexpr MQTT_TEMP_BUFFER_REVERT[] = "Reverting temporarily increased receive buffer size for OTA update back too (%u)";
+char constexpr SKIP_TEMP_BUFFER_INCREASE[] = "Buffer size of (%u) is already big enough to hold maximum received data from OTA update (%u), skipping increase";
 #endif // THINGSBOARD_ENABLE_DEBUG
 
 
@@ -279,6 +282,9 @@ class OTA_Firmware_Update : public IAPI_Implementation {
         // to allow to receive ota chunck packets that might be much bigger than the normal
         // buffer size would allow, therefore we return to the previous value to decrease overall memory usage
         if (m_changed_buffer_size) {
+#if THINGSBOARD_ENABLE_DEBUG
+            Logger::printfln(MQTT_TEMP_BUFFER_REVERT, m_previous_buffer_size);
+#endif // THINGSBOARD_ENABLE_DEBUG
             (void)m_set_buffer_size_callback.Call_Callback(m_previous_buffer_size, m_get_send_size_callback.Call_Callback());
         }
         // Reset now not needed private member variables
@@ -393,14 +399,19 @@ class OTA_Firmware_Update : public IAPI_Implementation {
 
         // Calculate the number of chuncks we need to request,
         // in order to download the complete firmware binary
-        const uint16_t& chunk_size = m_fw_callback.Get_Chunk_Size();
+        uint16_t const & chunk_size = m_fw_callback.Get_Chunk_Size();
 
         // Get the previous buffer size and cache it so the previous settings can be restored.
         m_previous_buffer_size = m_get_receive_size_callback.Call_Callback();
-        m_changed_buffer_size = m_previous_buffer_size < (chunk_size + 50U);
+        uint16_t const target_buffer_size = (chunk_size + 50U);
+        m_changed_buffer_size = m_previous_buffer_size < target_buffer_size;
+
+#if THINGSBOARD_ENABLE_DEBUG
+        Logger::printfln(m_changed_buffer_size ? MQTT_TEMP_BUFFER_INCREASE : SKIP_TEMP_BUFFER_INCREASE, m_previous_buffer_size, target_buffer_size);
+#endif // THINGSBOARD_ENABLE_DEBUG
 
         // Increase size of receive buffer
-        if (m_changed_buffer_size && !m_set_buffer_size_callback.Call_Callback(chunk_size + 50U, m_get_send_size_callback.Call_Callback())) {
+        if (m_changed_buffer_size && !m_set_buffer_size_callback.Call_Callback(target_buffer_size, m_get_send_size_callback.Call_Callback())) {
             Logger::printfln(NOT_ENOUGH_RAM);
             Firmware_Send_State(FW_STATE_FAILED, NOT_ENOUGH_RAM);
             m_fw_callback.Call_Callback(false);

--- a/src/OTA_Firmware_Update.h
+++ b/src/OTA_Firmware_Update.h
@@ -193,7 +193,7 @@ class OTA_Firmware_Update : public IAPI_Implementation {
         // Nothing to do
     }
 
-    bool Compare_Response_Topic(char const * topic) const override {
+    bool Is_Response_Topic_Matching(char const * topic) const override {
         return strncmp(m_response_topic, topic, strlen(m_response_topic)) == 0;
     }
 
@@ -202,7 +202,7 @@ class OTA_Firmware_Update : public IAPI_Implementation {
         return true;
     }
 
-    bool Resubscribe_Topic() override {
+    bool Resubscribe_Permanent_Subscriptions() override {
         return Firmware_OTA_Subscribe();
     }
 

--- a/src/OTA_Update_Callback.h
+++ b/src/OTA_Update_Callback.h
@@ -47,6 +47,8 @@ class OTA_Update_Callback : public Callback<void, bool const &> {
     /// until that chunk counts as a timeout, retries is then subtraced by one and the download is retried, default = REQUEST_TIMEOUT
     OTA_Update_Callback(char const * current_fw_title, char const * current_fw_version, IUpdater * updater, function finished_callback, Callback<void, size_t const &, size_t const &>::function progress_callback = nullptr, Callback<void>::function update_starting_callback = nullptr, uint8_t chunk_retries = CHUNK_RETRIES, uint16_t chunk_size = CHUNK_SIZE, uint64_t const & timeout_microseconds = REQUEST_TIMEOUT);
 
+    ~OTA_Update_Callback() override = default;
+
     /// @brief Gets the current firmware title, used to decide if an OTA firmware update is already installed and therefore should not be downladed,
     /// this is only done if the title of the update and the current firmware title are the same because if they are not then this firmware is meant for another device type
     /// @return Current firmware title of the device

--- a/src/Provision.h
+++ b/src/Provision.h
@@ -30,6 +30,8 @@ class Provision : public IAPI_Implementation {
     /// @brief Constructor
     Provision() = default;
 
+    ~Provision() override = default;
+
     /// @brief Sends provisioning request for a new device, meaning we want to create a device that we can then connect over,
     /// where the given provision device key / secret decide which device profile is used to create the given device with.
     /// Optionally a device name can be passed or be left empty (cloud will use a random string as the name instead).

--- a/src/Provision.h
+++ b/src/Provision.h
@@ -107,7 +107,7 @@ class Provision : public IAPI_Implementation {
         (void)Provision_Unsubscribe();
     }
 
-    bool Compare_Response_Topic(char const * topic) const override {
+    bool Is_Response_Topic_Matching(char const * topic) const override {
         return strncmp(PROV_RESPONSE_TOPIC, topic, strlen(PROV_RESPONSE_TOPIC) + 1) == 0;
     }
 
@@ -115,7 +115,7 @@ class Provision : public IAPI_Implementation {
         return Provision_Unsubscribe();
     }
 
-    bool Resubscribe_Topic() override {
+    bool Resubscribe_Permanent_Subscriptions() override {
         m_provision_callback = Provision_Callback();
         return true;
     }
@@ -148,7 +148,7 @@ private:
     /// @return Whether unsubcribing the previously subscribed callback
     /// and from the provision response topic, was successful or not
     bool Provision_Unsubscribe() {
-        return Resubscribe_Topic();
+        return Resubscribe_Permanent_Subscriptions();
     }
 
     Callback<bool, char const * const, JsonDocument const &, size_t const &> m_send_json_callback = {};         // Send json document callback

--- a/src/Provision_Callback.h
+++ b/src/Provision_Callback.h
@@ -77,6 +77,8 @@ class Provision_Callback : public Callback<void, JsonDocument const &> {
     /// or if the connection could not be established, default = nullptr
     Provision_Callback(X509_Certificate, function callback, char const * provision_device_key, char const * provision_device_secret, char const * hash, char const * device_name = nullptr, uint64_t const & timeout_microseconds = 0U, Callback_Watchdog::function timeout_callback = nullptr);
 
+    ~Provision_Callback() override = default;
+
     /// @brief Gets the device profile provisioning key of the device profile,
     /// that should be used to create the device under
     /// @return Device profile provisioning key

--- a/src/RPC_Callback.h
+++ b/src/RPC_Callback.h
@@ -35,6 +35,8 @@ class RPC_Callback : public Callback<void, JsonVariantConst const &, JsonDocumen
         // Nothing to do
     }
 
+    ~RPC_Callback() override = default;
+
     /// @brief Gets the poiner to the underlying name we expect to be sent via. server-side RPC so that this method callback will be called
     /// @return Pointer to the passed method name
     char const * Get_Name() const {

--- a/src/RPC_Request_Callback.h
+++ b/src/RPC_Request_Callback.h
@@ -24,6 +24,8 @@ class RPC_Request_Callback : public Callback<void, JsonDocument const &> {
     /// or if the connection could not be established, default = nullptr
     RPC_Request_Callback(char const * method_name, function received_callback, JsonArray const * parameters = nullptr, uint64_t const & timeout_microseconds = 0U, Callback_Watchdog::function timeout_callback = nullptr);
 
+    ~RPC_Request_Callback() override = default;
+
     /// @brief Gets the unique request identifier that is connected to the original request,
     /// and will be later used to verifiy which RPC_Request_Callback
     /// is connected to which received client-side RPC response

--- a/src/SDCard_Updater.h
+++ b/src/SDCard_Updater.h
@@ -22,6 +22,10 @@ class SDCard_Updater : public IUpdater {
         // Nothing to do
     }
 
+    ~SDCard_Updater() override {
+        reset();
+    }
+
     bool begin(size_t const & firmware_size) override {
         FILE* file = fopen(m_path, "w");
         if (file == nullptr) {

--- a/src/Server_Side_RPC.h
+++ b/src/Server_Side_RPC.h
@@ -60,7 +60,7 @@ class Server_Side_RPC : public IAPI_Implementation {
 #if !THINGSBOARD_ENABLE_DYNAMIC
         size_t const size = Helper::distance(first, last);
         if (m_rpc_callbacks.size() + size > m_rpc_callbacks.capacity()) {
-            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, MAX_SUBSCRIPTIONS_TEMPLATE_NAME, SERVER_SIDE_RPC_SUBSCRIPTIONS);
+            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, SERVER_SIDE_RPC_SUBSCRIPTIONS, MAX_SUBSCRIPTIONS_TEMPLATE_NAME);
             return false;
         }
 #endif // !THINGSBOARD_ENABLE_DYNAMIC
@@ -83,7 +83,7 @@ class Server_Side_RPC : public IAPI_Implementation {
     bool RPC_Subscribe(RPC_Callback const & callback) {
 #if !THINGSBOARD_ENABLE_DYNAMIC
         if (m_rpc_callbacks.size() + 1 > m_rpc_callbacks.capacity()) {
-            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, MAX_SUBSCRIPTIONS_TEMPLATE_NAME, SERVER_SIDE_RPC_SUBSCRIPTIONS);
+            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, SERVER_SIDE_RPC_SUBSCRIPTIONS, MAX_SUBSCRIPTIONS_TEMPLATE_NAME);
             return false;
         }
 #endif // !THINGSBOARD_ENABLE_DYNAMIC

--- a/src/Server_Side_RPC.h
+++ b/src/Server_Side_RPC.h
@@ -171,7 +171,7 @@ class Server_Side_RPC : public IAPI_Implementation {
         }
     }
 
-    bool Compare_Response_Topic(char const * topic) const override {
+    bool Is_Response_Topic_Matching(char const * topic) const override {
         return strncmp(RPC_REQUEST_TOPIC, topic, strlen(RPC_REQUEST_TOPIC)) == 0;
     }
 
@@ -179,7 +179,7 @@ class Server_Side_RPC : public IAPI_Implementation {
         return RPC_Unsubscribe();
     }
 
-    bool Resubscribe_Topic() override {
+    bool Resubscribe_Permanent_Subscriptions() override {
         if (!m_rpc_callbacks.empty() && !m_subscribe_topic_callback.Call_Callback(RPC_SUBSCRIBE_TOPIC)) {
             Logger::printfln(SUBSCRIBE_TOPIC_FAILED, RPC_SUBSCRIBE_TOPIC);
             return false;

--- a/src/Server_Side_RPC.h
+++ b/src/Server_Side_RPC.h
@@ -41,6 +41,8 @@ class Server_Side_RPC : public IAPI_Implementation {
     /// @brief Constructor
     Server_Side_RPC() = default;
 
+    ~Server_Side_RPC() override = default;
+
     /// @brief Subscribes multiple server side RPC callbacks,
     /// that will be called if a request from the server for the method with the given name is received.
     /// Can be called even if we are currently not connected to the cloud,

--- a/src/Shared_Attribute_Callback.h
+++ b/src/Shared_Attribute_Callback.h
@@ -43,6 +43,8 @@ class Shared_Attribute_Callback : public Callback<void, JsonObjectConst const &>
         // Nothing to do
     }
 
+    ~Shared_Attribute_Callback() override = default;
+
     /// @brief Gets all the subscribed shared attributes that will result,
     /// in the subscribed method being called if any of those attributes values is changed by the cloud,
     /// with their current value they have been changed to

--- a/src/Shared_Attribute_Update.h
+++ b/src/Shared_Attribute_Update.h
@@ -47,7 +47,7 @@ class Shared_Attribute_Update : public IAPI_Implementation {
 #if !THINGSBOARD_ENABLE_DYNAMIC
         size_t const size = Helper::distance(first, last);
         if (m_shared_attribute_update_callbacks.size() + size > m_shared_attribute_update_callbacks.capacity()) {
-            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, MAX_SUBSCRIPTIONS_TEMPLATE_NAME, SHARED_ATTRIBUTE_UPDATE_SUBSCRIPTIONS);
+            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, SHARED_ATTRIBUTE_UPDATE_SUBSCRIPTIONS, MAX_SUBSCRIPTIONS_TEMPLATE_NAME);
             return false;
         }
 #endif // !THINGSBOARD_ENABLE_DYNAMIC
@@ -74,7 +74,7 @@ class Shared_Attribute_Update : public IAPI_Implementation {
 #endif // THINGSBOARD_ENABLE_DYNAMIC
 #if !THINGSBOARD_ENABLE_DYNAMIC
         if (m_shared_attribute_update_callbacks.size() + 1U > m_shared_attribute_update_callbacks.capacity()) {
-            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, MAX_SUBSCRIPTIONS_TEMPLATE_NAME, SHARED_ATTRIBUTE_UPDATE_SUBSCRIPTIONS);
+            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, SHARED_ATTRIBUTE_UPDATE_SUBSCRIPTIONS, MAX_SUBSCRIPTIONS_TEMPLATE_NAME);
             return false;
         }
 #endif // !THINGSBOARD_ENABLE_DYNAMIC

--- a/src/Shared_Attribute_Update.h
+++ b/src/Shared_Attribute_Update.h
@@ -28,6 +28,8 @@ class Shared_Attribute_Update : public IAPI_Implementation {
     /// @brief Constructor
     Shared_Attribute_Update() = default;
 
+    ~Shared_Attribute_Update() override = default;
+
     /// @brief Subscribes multiple shared attribute callbacks,
     /// that will be called if the key-value pair from the server for the given shared attributes is received.
     /// Can be called even if we are currently not connected to the cloud,

--- a/src/Shared_Attribute_Update.h
+++ b/src/Shared_Attribute_Update.h
@@ -160,7 +160,7 @@ class Shared_Attribute_Update : public IAPI_Implementation {
         }
     }
 
-    bool Compare_Response_Topic(char const * topic) const override {
+    bool Is_Response_Topic_Matching(char const * topic) const override {
         return strncmp(ATTRIBUTE_TOPIC, topic, strlen(ATTRIBUTE_TOPIC) + 1) == 0;
     }
 
@@ -168,7 +168,7 @@ class Shared_Attribute_Update : public IAPI_Implementation {
         return Shared_Attributes_Unsubscribe();
     }
 
-    bool Resubscribe_Topic() override {
+    bool Resubscribe_Permanent_Subscriptions() override {
         if (!m_shared_attribute_update_callbacks.empty() && !m_subscribe_topic_callback.Call_Callback(ATTRIBUTE_TOPIC)) {
             Logger::printfln(SUBSCRIBE_TOPIC_FAILED, ATTRIBUTE_TOPIC);
             return false;

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -286,7 +286,7 @@ class ThingsBoardSized {
 #if THINGSBOARD_ENABLE_STREAM_UTILS
         // Check if the size of the given message would be too big for the actual client,
         // if it is utilize the serialize json work around, so that the internal client buffer can be circumvented
-        if (m_client.get_buffer_size() < json_size)  {
+        if (m_client.get_send_buffer_size() < json_size)  {
 #if THINGSBOARD_ENABLE_DEBUG
             Logger::printfln(SEND_MESSAGE, topic, SEND_SERIALIZED);
 #endif // THINGSBOARD_ENABLE_DEBUG

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -24,6 +24,8 @@ char constexpr MAX_ENDPOINTS_AMOUNT_TEMPLATE_NAME[] = "MaxEndpointsAmount";
 #if THINGSBOARD_ENABLE_DYNAMIC
 char constexpr MAXIMUM_RESPONSE_EXCEEDED[] = "Prevented allocation on the heap (%u) for JsonDocument. Discarding message that is bigger than maximum response size (%u)";
 char constexpr HEAP_ALLOCATION_FAILED[] = "Failed allocating required size (%u) for JsonDocument. Ensure there is enough heap memory left";
+#else
+char constexpr API_SUBSCRIPTIONS[] = "API implementation";
 #endif // THINGSBOARD_ENABLE_DYNAMIC
 #if THINGSBOARD_ENABLE_DEBUG
 char constexpr RECEIVE_MESSAGE[] = "Received (%u) bytes of data from server over topic (%s)";
@@ -363,7 +365,7 @@ class ThingsBoardSized {
     void Subscribe_API_Implementation(IAPI_Implementation & api) {
 #if !THINGSBOARD_ENABLE_DYNAMIC
         if (m_api_implementations.size() + 1 > m_api_implementations.capacity()) {
-            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, MAX_ENDPOINTS_AMOUNT_TEMPLATE_NAME, MaxEndpointsAmount);
+            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, API_SUBSCRIPTIONS, MAX_ENDPOINTS_AMOUNT_TEMPLATE_NAME);
             return;
         }
 #endif // !THINGSBOARD_ENABLE_DYNAMIC
@@ -389,7 +391,7 @@ class ThingsBoardSized {
 #if !THINGSBOARD_ENABLE_DYNAMIC
         size_t const size = Helper::distance(first, last);
         if (m_api_implementations.size() + size > m_api_implementations.capacity()) {
-            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, MAX_ENDPOINTS_AMOUNT_TEMPLATE_NAME, MaxEndpointsAmount);
+            Logger::printfln(MAX_SUBSCRIPTIONS_EXCEEDED, API_SUBSCRIPTIONS, MAX_ENDPOINTS_AMOUNT_TEMPLATE_NAME);
             return;
         }
 #endif // !THINGSBOARD_ENABLE_DYNAMIC

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -262,9 +262,7 @@ class ThingsBoardSized {
         m_client.set_connection_state_changed_callback(callback);
     }
 
-    /// @brief Receives / sends any outstanding messages from and to the MQTT broker.
-    /// Additionally when not being able to use the ESP Timer, it updates the internal timeout timers
-    /// @return Whether sending or receiving the oustanding the messages was successful or not
+    /// @copybrief IMQTT_Client::loop
     bool loop() {
 #if !THINGSBOARD_USE_ESP_TIMER
         for (auto & api : m_api_implementations) {

--- a/src/ThingsBoardHttp.h
+++ b/src/ThingsBoardHttp.h
@@ -58,7 +58,7 @@ class ThingsBoardHttpSized {
 
     /// @brief Sets the maximum amount of bytes that we want to allocate on the stack, before the memory is allocated on the heap instead
     /// @param max_stack_size Maximum amount of bytes we want to allocate on the stack
-    void setMaximumStackSize(size_t const & max_stack_size) {
+    void Set_Maximum_Stack_Size(size_t const & max_stack_size) {
         m_max_stack = max_stack_size;
     }
 
@@ -82,7 +82,7 @@ class ThingsBoardHttpSized {
             return false;
         }
         bool result = false;
-        if (getMaximumStackSize() < json_size) {
+        if (Get_Maximum_Stack_Size() < json_size) {
             char * json = new char[json_size]();
             if (serializeJson(source, json, json_size) < json_size - 1) {
                 Logger::printfln(UNABLE_TO_SERIALIZE_JSON);
@@ -117,7 +117,7 @@ class ThingsBoardHttpSized {
 
         char path[Helper::detectSize(topic, m_token)] = {};
         (void)snprintf(path, sizeof(path), topic, m_token);
-        return postMessage(path, json);
+        return Post_Message(path, json);
     }
 
     //----------------------------------------------------------------------------
@@ -130,8 +130,8 @@ class ThingsBoardHttpSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     template<typename T>
-    bool sendTelemetryData(char const * key, T const & value) {
-        return sendKeyValue(key, value);
+    bool Send_Telemetry_Data(char const * key, T const & value) {
+        return Send_Key_Value_Pair(key, value);
     }
 
     /// @brief Attempts to send aggregated telemetry data, expects iterators to a container containing Telemetry class instances.
@@ -149,11 +149,11 @@ class ThingsBoardHttpSized {
     /// Should simply be the biggest distance between first and last iterator this method is ever called with
     template<size_t MaxKeyValuePairAmount, typename InputIterator>
 #endif // THINGSBOARD_ENABLE_DYNAMIC
-    bool sendTelemetry(InputIterator const & first, InputIterator const & last) {
+    bool Send_Telemetry(InputIterator const & first, InputIterator const & last) {
 #if THINGSBOARD_ENABLE_DYNAMIC
-        return sendDataArray(first, last, true);
+        return Send_Data_Array(first, last, true);
 #else
-        return sendDataArray<MaxKeyValuePairAmount>(first, last, true);
+        return Send_Data_Array<MaxKeyValuePairAmount>(first, last, true);
 #endif // THINGSBOARD_ENABLE_DYNAMIC
     }
 
@@ -161,7 +161,7 @@ class ThingsBoardHttpSized {
     /// See https://thingsboard.io/docs/user-guide/telemetry/ for more information
     /// @param json String containing our json key value pairs we want to attempt to send
     /// @return Whetherr sending the data was successful or not
-    bool sendTelemetryString(char const * json) {
+    bool Send_Telemetry_String(char const * json) {
         return Send_Json_String(HTTP_TELEMETRY_TOPIC, json);
     }
 
@@ -171,7 +171,7 @@ class ThingsBoardHttpSized {
     /// is checked before usage for any possible occuring internal errors. See https://arduinojson.org/v6/api/jsondocument/ for more information
     /// @param json_size Size of the data inside the source
     /// @return Whether sending the data was successful or not
-    bool sendTelemetryJson(JsonDocument const & source, size_t const & json_size) {
+    bool Send_Telemetry_Json(JsonDocument const & source, size_t const & json_size) {
         return Send_Json(HTTP_TELEMETRY_TOPIC, source, json_size);
     }
 
@@ -181,19 +181,19 @@ class ThingsBoardHttpSized {
     /// will not be changed if the GET request wasn't successful
     /// @return Whetherr sending the GET request was successful or not
 #if THINGSBOARD_ENABLE_STL
-    bool sendGetRequest(char const * path, std::string & response) {
+    bool Send_Get_Request(char const * path, std::string & response) {
 #else
-    bool sendGetRequest(char const * path, String& response) {
+    bool Send_Get_Request(char const * path, String& response) {
 #endif // THINGSBOARD_ENABLE_STL
-        return getMessage(path, response);
+        return Get_Message(path, response);
     }
 
     /// @brief Attempts to send a POST request over HTTP or HTTPS
     /// @param path API path we want to send data to (example: /api/v1/$TOKEN/attributes)
     /// @param json String containing our json key value pairs we want to attempt to send
     /// @return Whetherr sending the POST request was successful or not
-    bool sendPostRequest(char const * path, char const * json) {
-        return postMessage(path, json);
+    bool Send_Post_Request(char const * path, char const * json) {
+        return Post_Message(path, json);
     }
 
     //----------------------------------------------------------------------------
@@ -206,8 +206,8 @@ class ThingsBoardHttpSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     template<typename T>
-    bool sendAttributeData(char const * key, T const & value) {
-        return sendKeyValue(key, value, false);
+    bool Send_Attribute_Data(char const * key, T const & value) {
+        return Send_Key_Value_Pair(key, value, false);
     }
 
     /// @brief Attempts to send aggregated attribute data, expects iterators to a container containing Attribute class instances.
@@ -225,11 +225,11 @@ class ThingsBoardHttpSized {
     /// Should simply be the biggest distance between first and last iterator this method is ever called with
     template<size_t MaxKeyValuePairAmount, typename InputIterator>
 #endif // THINGSBOARD_ENABLE_DYNAMIC
-    bool sendAttributes(InputIterator const & first, InputIterator const & last) {
+    bool Send_Attributes(InputIterator const & first, InputIterator const & last) {
 #if THINGSBOARD_ENABLE_DYNAMIC
-        return sendDataArray(first, last, false);
+        return Send_Data_Array(first, last, false);
 #else
-        return sendDataArray<MaxKeyValuePairAmount>(first, last, false);
+        return Send_Data_Array<MaxKeyValuePairAmount>(first, last, false);
 #endif // THINGSBOARD_ENABLE_DYNAMIC
     }
 
@@ -237,7 +237,7 @@ class ThingsBoardHttpSized {
     /// See https://thingsboard.io/docs/user-guide/attributes/ for more information
     /// @param json String containing our json key value pairs we want to attempt to send
     /// @return Whetherr sending the data was successful or not
-    bool sendAttributeString(char const * json) {
+    bool Send_Attribute_String(char const * json) {
         return Send_Json_String(HTTP_ATTRIBUTES_TOPIC, json);
     }
 
@@ -247,20 +247,20 @@ class ThingsBoardHttpSized {
     /// is checked before usage for any possible occuring internal errors. See https://arduinojson.org/v6/api/jsondocument/ for more information
     /// @param json_size Size of the data inside the source
     /// @return Whether sending the data was successful or not
-    bool sendAttributeJson(JsonDocument const & source, size_t const & json_size) {
+    bool Send_Attribute_Json(JsonDocument const & source, size_t const & json_size) {
         return Send_Json(HTTP_ATTRIBUTES_TOPIC, source, json_size);
     }
 
   private:
     /// @brief Returns the maximum amount of bytes that we want to allocate on the stack, before the memory is allocated on the heap instead
     /// @return Maximum amount of bytes we want to allocate on the stack
-    size_t const & getMaximumStackSize() const {
+    size_t const & Get_Maximum_Stack_Size() const {
         return m_max_stack;
     }
 
     /// @brief Clears any remaining memory of the previous conenction,
     /// and resets the TCP as well, if data is resend the TCP connection has to be re-established
-    void clearConnection() {
+    void Clear_Connection() {
         m_client.stop();
     }
 
@@ -268,7 +268,7 @@ class ThingsBoardHttpSized {
     /// @param path API path we want to send data to (example: /api/v1/$TOKEN/attributes)
     /// @param json String containing our json key value pairs we want to attempt to send
     /// @return Whetherr sending the POST request was successful or not
-    bool postMessage(char const * path, char const * json) {
+    bool Post_Message(char const * path, char const * json) {
         bool success = m_client.post(path, HTTP_POST_PATH, json) == 0;
         int const status = m_client.get_response_status_code();
 
@@ -277,7 +277,7 @@ class ThingsBoardHttpSized {
             success = false;
         }
 
-        clearConnection();
+        Clear_Connection();
         return success;
     }
 
@@ -287,9 +287,9 @@ class ThingsBoardHttpSized {
     /// will not be changed if the GET request wasn't successful
     /// @return Whetherr sending the GET request was successful or not
 #if THINGSBOARD_ENABLE_STL
-    bool getMessage(char const * path, std::string& response) {
+    bool Get_Message(char const * path, std::string& response) {
 #else
-    bool getMessage(char const * path, String& response) {
+    bool Get_Message(char const * path, String& response) {
 #endif // THINGSBOARD_ENABLE_STL
         bool success = m_client.get(path);
         int const status = m_client.get_response_status_code();
@@ -302,7 +302,7 @@ class ThingsBoardHttpSized {
         response = m_client.get_response_body();
 
         cleanup:
-        clearConnection();
+        Clear_Connection();
         return success;
     }
 
@@ -321,7 +321,7 @@ class ThingsBoardHttpSized {
     /// Should simply be the biggest distance between first and last iterator this method is ever called with
     template<size_t MaxKeyValuePairAmount, typename InputIterator>
 #endif // THINGSBOARD_ENABLE_DYNAMIC
-    bool sendDataArray(InputIterator const & first, InputIterator const & last, bool telemetry) {
+    bool Send_Data_Array(InputIterator const & first, InputIterator const & last, bool telemetry) {
         size_t const size = Helper::distance(first, last);
 #if THINGSBOARD_ENABLE_DYNAMIC
         TBJsonDocument json_buffer(JSON_OBJECT_SIZE(size));
@@ -347,7 +347,7 @@ class ThingsBoardHttpSized {
             }
         }
 #endif // THINGSBOARD_ENABLE_STL
-        return telemetry ? sendTelemetryJson(json_buffer, Helper::Measure_Json(json_buffer)) : sendAttributeJson(json_buffer, Helper::Measure_Json(json_buffer));
+        return telemetry ? Send_Telemetry_Json(json_buffer, Helper::Measure_Json(json_buffer)) : Send_Attribute_Json(json_buffer, Helper::Measure_Json(json_buffer));
     }
 
     /// @brief Sends single key-value attribute or telemetry data in a generic way
@@ -357,7 +357,7 @@ class ThingsBoardHttpSized {
     /// @param telemetry Whetherr the aggregated data is telemetry (true) or attribut (false)
     /// @return Whetherr sending the data was successful or not
     template<typename T>
-    bool sendKeyValue(char const * key, T value, bool telemetry = true) {
+    bool Send_Key_Value_Pair(char const * key, T value, bool telemetry = true) {
         Telemetry const t(key, value);
         if (t.IsEmpty()) {
             // Message is ignored and not sent at all.
@@ -369,7 +369,7 @@ class ThingsBoardHttpSized {
             Logger::printfln(UNABLE_TO_SERIALIZE);
             return false;
         }
-        return telemetry ? sendTelemetryJson(json_buffer, Helper::Measure_Json(json_buffer)) : sendAttributeJson(json_buffer, Helper::Measure_Json(json_buffer));
+        return telemetry ? Send_Telemetry_Json(json_buffer, Helper::Measure_Json(json_buffer)) : Send_Attribute_Json(json_buffer, Helper::Measure_Json(json_buffer));
     }
 
     IHTTP_Client& m_client = {};     // HttpClient instance


### PR DESCRIPTION
Improved the underlying `IMQTT _Client` Interface, with the option to either subscribe a callback that is informed whenever the underyling connection changes state (Connected, Connecting, Disconnected, Disconencting) or to directly read the current state. Additionally the exact error reason for the failure to connect is also received in the callback and can be read from the client as well.

This allows to better manage the current state of the client, because the `Espressif_MQTT_Client`, does not connect in a blocking way like `Arduino_MQTT_Client`, but instead sends a connect request and then returns immediately and will be informed again once the connection was successfull.

Additionally fixed an edge case where the connected state was set to true in the `Arduino_MQTT_Client`, even tough the connect method timed out or failed, because of invalid credentials.

----------------------

Furthermore multiple issues have been fixed including fixed of other Pull Requests. Closes #254, closes #242.

Array class has been adjusted to fix compilation issue, because setting the template parameter to 0 was possible. Closes #239.

Arduino_HTTP_Client has issues in combination with ESP-IDF Arduino, because of changes in Interface. Should have been reverted. Closes #240.

Adjust code to append additional null termination to Attribute Request char array. Closes #245.

Fix provisioning unsubscribe call causing disconnect with cloud and connect cloud not even doing anything at all. Closes #247. Closes #248.

Fix typo and adjust examples. Closes #238. Closes #250. Closes #241. Closes #243. Closes #246. Closes #256.

@imbeacon Would be nice if this could be merged and released as `v0.15.0` on PlatformIO, Arduino and Espressif Registry, as it includes a lot of vital bug fixes for provisioning and other features.

